### PR TITLE
Add ability to load CMI data from a JSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ To use, you must include the scormAPI.js file on the launching page of your SCOR
 <script type="text/javascript" src="/scormAPI.js"></script>
 ```
 
-This will create a SCORM API object on the window (required by SCORM 1.2) and thats it!! 
+This will create a SCORM API object on the window (required by SCORM 1.2) and thats it!!
 
 No Really
 
-This will handle all the scorm interactions, and record everything on the object at 
+This will handle all the scorm interactions, and record everything on the object at
 
 ```javascript
 window.API.cmi
@@ -51,10 +51,10 @@ window.API.on('LMSSetValue.cmi.core.student_id', function(CMIElement, value) {
 Obviously, you will need to tie into the close, or complete event, or otherwise monitor your SCORM player to finalize the session, at that time, you can perform a JSON.stringify on the CMI object to retrieve a simplified data form for sending to your backend API,
 
 ```javascript
-  var simplifiedObject = window.API.cmi.toJSON();
+var simplifiedObject = window.API.cmi.toJSON();
 ```
 
-Example Output: 
+Example Output:
 ```json
 {
   "suspend_data": "viewed=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31|lastviewedslide=31|7#1##,3,3,3,7,3,3,7,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,11#0#b5e89fbb-7cfb-46f0-a7cb-758165d3fe7e=236~262~2542812732762722742772682802752822882852892872832862962931000~3579~32590001001010101010101010101001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001001010010010010010010010010011010010010010010010010010010010010112101021000171000~236a71d398e-4023-4967-88fe-1af18721422d06passed6failed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000105wrong110000000000000000000000000000000000~3185000000000000000000000000000000000000000000000000000000000000000000000000000000000~283~2191w11~21113101w41689~256~2100723031840~21007230314509062302670~2110723031061120000000000000000000~240~234531618~21601011000100000002814169400,#-1",
@@ -79,7 +79,7 @@ Example Output:
   },
   "objectives": {
     "childArray": [
-      
+
     ]
   },
   "student_data": {
@@ -126,16 +126,56 @@ Example Output:
 ## Initial Values
 Lastly, if you are doing an initial load of your data from the backend API, you will need to initialize your variables on the CMI object before launching your SCORM 1.2 player. After the player has initialized - you will not be able to set any read only values:
 
-<code>
-  window.API.cmi.core.student_id = '123';
-</code>
+```javascript
+window.API.cmi.core.student_id = '123';
+```
+
+You can also initialize the CMI object in bulk by supplying a JSON object whose structure matches the output of `window.API.cmi.toJSON()`. Note that it can be a partial CMI object:
+
+```javascript
+var json = {
+  "suspend_data": "...",
+  "core": {
+    "student_id": "",
+    "student_name": ""
+  },
+  "interactions": {
+    "childArray": [
+      {
+        "id": "Question14_1",
+        "time": "11:05:21",
+        "type": "choice",
+        "weighting": "1",
+        "student_response": "HTH",
+        "result": "wrong",
+        "latency": "0000:00:01.68",
+        "objectives": {
+          "childArray": [
+            {
+              "id": "Question14_1"
+            }
+          ]
+        },
+        "correct_responses": {
+          "childArray": [
+            {
+              "pattern": "CPR"
+            }
+          ]
+        }
+      }
+    ]
+  }
+};
+window.API.loadFromJSON(json);
+```
 
 ## Logging
 By default, the API is set to only output errors in the Javascript console, * if you want to change this level * you can change it by setting the the apiLogLevel to the appropriate level:
 
-<code>
-  window.API.apiLogLevel = 5 //no logging
-</code>
+```javascript
+window.API.apiLogLevel = 5; // No logging
+```
 
 Hopefully this makes your life easier, and lets you get up and running much faster in your SCORM developing!!!
 

--- a/src/scormAPI.js
+++ b/src/scormAPI.js
@@ -32,6 +32,7 @@
     // Utility Functions
     _self.checkState = checkState;
     _self.getLmsErrorMessageDetails = getLmsErrorMessageDetails;
+    _self.loadFromJSON = loadFromJSON;
 
     /**
      * @returns {string} bool
@@ -367,6 +368,35 @@
       }
 
       return detail ? detailMessage : basicMessage;
+    }
+
+    /**
+     * Loads CMI data from a JSON object.
+     */
+    function loadFromJSON(json, CMIElement) {
+      if (!_self.isNotInitialized()) {
+        console.error("loadFromJSON can only be called before the call to LMSInitialize.");
+        return;
+      }
+
+      CMIElement = CMIElement || "cmi";
+
+      for (var key in json) {
+        if (json.hasOwnProperty(key) && json[key]) {
+          var currentCMIElement = CMIElement + "." + key;
+          var value = json[key];
+
+          if (value["childArray"]) {
+            for (var i = 0; i < value["childArray"].length; i++) {
+              _self.loadFromJSON(value["childArray"][i], currentCMIElement + "." + i);
+            }
+          } else if (value.constructor === Object) {
+            _self.loadFromJSON(value, currentCMIElement);
+          } else {
+            setCMIValue(currentCMIElement, value);
+          }
+        }
+      }
     }
 
     return _self;


### PR DESCRIPTION
I had to place the method on window.API itself instead of on the cmi because I needed access to the setCMIValue method, and I didn't want to expose it so that the cmi object could access it.

So, instead of having a nicer-named `window.API.cmi.fromJSON()`, here is my take on `window.API.loadFromJSON()`

I also added an example on the README