### PR TITLE
Add Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "8"
+sudo: required
+dist: trusty
+addons:
+  chrome: stable

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "puppeteer": "^1.3.0",
     "sinon": "^5.0.4",
     "sinon-chai": "^3.0.0"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
This pull request adds the configuration necessary for a Travis CI integration to work with the project's test setup.

@gabrieldoty will need to enable the Travis CI integration though, as he is the owner of the repository, and only the owner can do that. Having tested the integration in my fork, I can confirm that the setup is quite easy. [Step-by-step instructions](https://docs.travis-ci.com/user/getting-started/#to-get-started-with-travis-ci).

You would only need to do steps 1 through 3, the rest is done in this pull request.