### PR TITLE
Change the way of bringing the API back to its original state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 2.0.0
+
+### Added
+
+- This CHANGELOG file to document changes to the project
+- The `reset` method should now be used instead of the previous
+  `replaceWithAnotherScormAPI` method. It resets the API to its original state
+  cleanly, instead of having to create a whole new API.
+
+### Removed
+
+- The `replaceWithAnotherScormAPI` method was removed. It caused issues with
+  SCOs that keep a pointer to the original API after replacing it a few times.

--- a/README.md
+++ b/README.md
@@ -213,23 +213,15 @@ window.API.apiLogLevel = 5; // No logging
 
 ## Resetting
 
-There may come a time when you need to reset the SCORM 1.2 API. Two methods are available.
-
-You can create a new API and replace the one available on `window.API`:
-
-```javascript
-window.API = new window.simplifyScorm.ScormAPI();
-```
-
-You can also create a new API and ask the existing one to use the new API instead.
+There may come a time when you need to reset the SCORM 1.2 API.
 This is useful when a SCORM object allows retrying after a failure, and you want to track each attempt in a separate CMI object.
-SCORM objects often keep a reference to the original API, which is why this manipulation is needed:
+SCORM objects often keep a reference to the original API, which is why we recommend resetting the API instead of creating a new one:
 
 ```javascript
-var newAPI = new window.simplifyScorm.ScormAPI();
-window.API.replaceWithAnotherScormAPI(newAPI);
-window.API = newAPI;
+window.API.reset();
 ```
+
+Resetting the API brings it back to its original state, including a brand new, untouched CMI object.
 
 # SCORM 2004
 
@@ -423,20 +415,12 @@ window.API_1484_11.apiLogLevel = 5; // No logging
 
 ## Resetting
 
-There may come a time when you need to reset the SCORM 2004 API. Two methods are available.
-
-You can create a new API and replace the one available on `window.API_1484_11`:
-
-```javascript
-window.API_1484_11 = new window.simplifyScorm.ScormAPI2004();
-```
-
-You can also create a new API and ask the existing one to use the new API instead.
+There may come a time when you need to reset the SCORM 2004 API.
 This is useful when a SCORM object allows retrying after a failure, and you want to track each attempt in a separate CMI object.
-SCORM objects often keep a reference to the original API, which is why this manipulation is needed:
+SCORM objects often keep a reference to the original API, which is why we recommend resetting the API instead of creating a new one:
 
 ```javascript
-var newAPI = new window.simplifyScorm.ScormAPI2004();
-window.API_1484_11.replaceWithAnotherScormAPI(newAPI);
-window.API_1484_11 = newAPI;
+window.API_1484_11.reset();
 ```
+
+Resetting the API brings it back to its original state, including a brand new, untouched CMI object.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify-scorm",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "",
   "license": "MIT",
   "private": true,

--- a/src/baseAPI.js
+++ b/src/baseAPI.js
@@ -23,6 +23,7 @@
     _self.processListeners = processListeners;
     _self.throwSCORMError = throwSCORMError;
   }
+  BaseAPI.reset = reset;
 
   /**
    * Logging for all SCORM actions
@@ -176,6 +177,19 @@
         listener.callback(CMIElement, value);
       }
     }
+  }
+
+  /**
+   * Reset the API to its initial state
+   */
+  function reset() {
+    // Internal State
+    this.currentState = constants.STATE_NOT_INITIALIZED;
+    this.lastErrorCode = 0;
+
+    // Utility Functions
+    this.apiLogLevel = constants.LOG_LEVEL_ERROR;
+    this.listenerArray = [];
   }
 
   /**

--- a/src/scormAPI.js
+++ b/src/scormAPI.js
@@ -35,7 +35,7 @@
     _self.checkState = checkState;
     _self.getLmsErrorMessageDetails = getLmsErrorMessageDetails;
     _self.loadFromJSON = loadFromJSON;
-    _self.replaceWithAnotherScormAPI = replaceWithAnotherScormAPI;
+    _self.reset = reset;
 
     /**
      * @returns {string} bool
@@ -412,30 +412,13 @@
     }
 
     /**
-     * Replace the whole API with another
+     * Reset the API to its initial state
      */
-    function replaceWithAnotherScormAPI(newAPI) {
-      // API Signature
-      _self.LMSInitialize = newAPI.LMSInitialize;
-      _self.LMSFinish = newAPI.LMSFinish;
-      _self.LMSGetValue = newAPI.LMSGetValue;
-      _self.LMSSetValue = newAPI.LMSSetValue;
-      _self.LMSCommit = newAPI.LMSCommit;
-      _self.LMSGetLastError = newAPI.LMSGetLastError;
-      _self.LMSGetErrorString = newAPI.LMSGetErrorString;
-      _self.LMSGetDiagnostic = newAPI.LMSGetDiagnostic;
+    function reset() {
+      BaseAPI.reset.call(_self);
 
       // Data Model
-      _self.cmi = newAPI.cmi;
-
-      // Utility Functions
-      _self.checkState = newAPI.checkState;
-      _self.getLmsErrorMessageDetails = newAPI.getLmsErrorMessageDetails;
-      _self.loadFromJSON = newAPI.loadFromJSON;
-      _self.replaceWithAnotherScormAPI = newAPI.replaceWithAnotherScormAPI;
-
-      // API itself
-      _self = newAPI; // eslint-disable-line consistent-this
+      _self.cmi = new CMI(_self);
     }
 
     return _self;

--- a/src/scormAPI2004.js
+++ b/src/scormAPI2004.js
@@ -40,7 +40,7 @@
     // Utility Functions
     _self.getLmsErrorMessageDetails = getLmsErrorMessageDetails;
     _self.loadFromJSON = loadFromJSON;
-    _self.replaceWithAnotherScormAPI = replaceWithAnotherScormAPI;
+    _self.reset = reset;
 
     /**
      * @param Empty String
@@ -511,30 +511,14 @@
     }
 
     /**
-     * Replace the whole API with another
+     * Reset the API to its initial state
      */
-    function replaceWithAnotherScormAPI(newAPI) {
-      // API Signature
-      _self.Initialize = newAPI.Initialize;
-      _self.Terminate = newAPI.Terminate;
-      _self.GetValue = newAPI.GetValue;
-      _self.SetValue = newAPI.SetValue;
-      _self.Commit = newAPI.Commit;
-      _self.GetLastError = newAPI.GetLastError;
-      _self.GetErrorString = newAPI.GetErrorString;
-      _self.GetDiagnostic = newAPI.GetDiagnostic;
+    function reset() {
+      BaseAPI.reset.call(_self);
 
       // Data Model
-      _self.cmi = newAPI.cmi;
-      _self.adl = newAPI.adl;
-
-      // Utility Functions
-      _self.getLmsErrorMessageDetails = newAPI.getLmsErrorMessageDetails;
-      _self.loadFromJSON = newAPI.loadFromJSON;
-      _self.replaceWithAnotherScormAPI = newAPI.replaceWithAnotherScormAPI;
-
-      // API itself
-      _self = newAPI; // eslint-disable-line consistent-this
+      _self.cmi = new CMI(_self);
+      _self.adl = new ADL(_self);
     }
 
     return _self;


### PR DESCRIPTION
I have discovered that the `replaceWithAnotherScormAPI` method is flawed. When an SCO keeps a pointer to the original API, after using this method a few times, something goes wrong. Hard to say what exactly, but it has to do with pointers not changing correctly. The SCO then starts writing to an old API that doesn't exist anymore, still triggers events, but then if you read from window.API, you get an empty dataset.

I have changed the approach completely. No more messing about with pointers. Instead, I go for a simple resetting of the default values, and replace the CMI object with a new one.

It's now a lot simpler to reset the API (one method to call instead of 3), and all the pointers follow correctly even if the SCO keeps a pointer to the initial API.

With this change, I suggest labelling the release as version 2.0.0, since there are breaking changes here. I also added a changelog, to start documenting the changes in the API.